### PR TITLE
Bump `a-tree` to 0.3.0

### DIFF
--- a/native/a_tree/Cargo.toml
+++ b/native/a_tree/Cargo.toml
@@ -11,5 +11,5 @@ path = "src/lib.rs"
 crate-type = ["dylib"]
 
 [dependencies]
-a-tree = "0.2.0"
+a-tree = "0.3.0"
 rustler = "0.35"


### PR DESCRIPTION
This fixes the parenthesis issues and add zero suppression filter